### PR TITLE
[#21] Replace http-conduit with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ What this tool should do: update all repositories in batches. Typical workflows 
    This helps with consistency.
 2. Propagate file updates.
 3. Run some checks over all repositories. For example, check whether they all have LICENSE, CONTRIBUTING, README files (etc.). 
+
+
+## Prerequisites
+
+To start using Crocodealer make sure that you have the following tools installed on your machine:
+
+* [`curl`](https://curl.haxx.se) – to download files.

--- a/crocodealer.cabal
+++ b/crocodealer.cabal
@@ -33,9 +33,8 @@ library
   build-depends:       base-noprelude ^>= 4.12.0.0
                      , relude ^>= 0.5.0
                      , tomland ^>= 1.1
-                     , http-conduit ^>= 2.3.7.3
-                     , http-types ^>= 0.12.3
                      , ansi-terminal ^>= 0.9.1
+                     , shellmet ^>= 0.0.3.0
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/src/Crocodealer/Command/Sync.hs
+++ b/src/Crocodealer/Command/Sync.hs
@@ -29,7 +29,7 @@ sync userName templateRepoName fileName repos =
 fetchGitHubFile :: UserName -> RepoName -> FileName -> IO (Maybe Text)
 fetchGitHubFile userName repoName fileName = do
     let url = "https://raw.githubusercontent.com/" <> unUserName userName <> "/" <> unRepoName repoName <> "/master/" <> unFileName fileName
-    (sequence . Just) ("curl" $| ["-s", "--fail", url]) $? pure Nothing
+    (Just <$> "curl" $| ["-s", "--fail", url]) $? pure Nothing
 
 printFileDiff :: UserName -> RepoName -> FileStatus -> IO ()
 printFileDiff (UserName user) (RepoName repo) = \case

--- a/src/Crocodealer/Command/Sync.hs
+++ b/src/Crocodealer/Command/Sync.hs
@@ -2,11 +2,10 @@ module Crocodealer.Command.Sync
        ( sync
        ) where
 
-import Network.HTTP.Simple (getResponseBody, getResponseStatus, httpBS, parseRequest)
-import Network.HTTP.Types.Status (Status (..))
-
 import Crocodealer.ColorTerminal (errorMessage, infoMessage, warningMessage)
 import Crocodealer.Core.GitHub (FileName (..), RepoName (..), UserName (..))
+
+import Shellmet (($|), ($?))
 
 
 data FileStatus
@@ -27,16 +26,10 @@ sync userName templateRepoName fileName repos =
                         let fileDiff = calculateDiff f r
                         printFileDiff userName repo fileDiff
 
-fetchGitHubFile :: UserName -> RepoName -> FileName -> IO (Maybe ByteString)
+fetchGitHubFile :: UserName -> RepoName -> FileName -> IO (Maybe Text)
 fetchGitHubFile userName repoName fileName = do
     let url = "https://raw.githubusercontent.com/" <> unUserName userName <> "/" <> unRepoName repoName <> "/master/" <> unFileName fileName
-    req <- parseRequest $ toString url
-    resp <- httpBS req
-
-    pure $ case getResponseStatus resp of
-        Status 200 _ -> Just $ getResponseBody resp
-        _            -> Nothing
-
+    (sequence . Just) ("curl" $| ["-s", "--fail", url]) $? pure Nothing
 
 printFileDiff :: UserName -> RepoName -> FileStatus -> IO ()
 printFileDiff (UserName user) (RepoName repo) = \case
@@ -50,7 +43,7 @@ printFileDiff (UserName user) (RepoName repo) = \case
     userRepo :: Text
     userRepo = user <> "/" <> repo <> ": "
 
-calculateDiff :: ByteString -> ByteString -> FileStatus
+calculateDiff :: Text -> Text -> FileStatus
 calculateDiff templateFile repoFile =
     if templateFile == repoFile
     then UpToDate


### PR DESCRIPTION
Fixes #21 

Maybe we should also list in the README that the library requires curl to work. Does that make sense?